### PR TITLE
Add error handling to create-sprint-boards

### DIFF
--- a/moc_sprint_tools/cmd/create_sprint_boards.py
+++ b/moc_sprint_tools/cmd/create_sprint_boards.py
@@ -100,8 +100,11 @@ def main(ctx, file, copy_cards):
             board = api.create_sprint(current_sprint[0])
 
             if previous_sprint and copy_cards:
-                previous_board = api.get_sprint(previous_sprint[0])
-                copy_board(previous_board, board)
+                try:
+                    previous_board = api.get_sprint(previous_sprint[0])
+                    copy_board(previous_board, board)
+                except BoardNotFoundError:
+                    LOG.error('previous sprint board %s does not exist', previous_sprint[0])
 
     except github.GithubException as err:
         raise click.ClickException(err)


### PR DESCRIPTION
If we have identified a previous sprint name but the corresponding
sprint board doesn't exist, trying to copy cards would throw a
traceback due to the BoardNotFound exception.

Emit a useful error message instead.